### PR TITLE
#11 implements Lucene queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,10 @@
         <open-metadata.version>2.7-SNAPSHOT</open-metadata.version>
         <crux.version>21.01-1.14.0-beta</crux.version>
         <crux-alpha.version>21.01-1.14.0-alpha</crux-alpha.version>
+        <!-- <crux-alpha.version>dev-SNAPSHOT</crux-alpha.version> -->
         <clojure.version>1.10.2</clojure.version>
         <jackson.version>2.12.1</jackson.version>
+        <lucene.version>8.6.1</lucene.version>
         <slf4j.version>1.7.30</slf4j.version>
         <!-- Platform encoding  -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -161,6 +163,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-queryparser</artifactId>
+                <version>${lucene.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
@@ -177,6 +185,18 @@
         <dependency>
             <groupId>juxt</groupId>
             <artifactId>crux-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>juxt</groupId>
+            <artifactId>crux-lucene</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>juxt</groupId>
+            <artifactId>crux-rocksdb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>juxt</groupId>
+            <artifactId>crux-kafka</artifactId>
         </dependency>
         <dependency>
             <groupId>org.clojure</groupId>
@@ -197,6 +217,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/org/odpi/egeria/connectors/juxt/crux/model/search/CruxGraphQuery.java
+++ b/src/main/java/org/odpi/egeria/connectors/juxt/crux/model/search/CruxGraphQuery.java
@@ -24,11 +24,9 @@ public class CruxGraphQuery extends CruxQuery {
 
     /**
      * Default constructor for a new query.
-     * @param defaultPageSize to use if no other is specified via addPaging
-     * @see #addPaging(int, int)
      */
-    public CruxGraphQuery(int defaultPageSize) {
-        super(defaultPageSize);
+    public CruxGraphQuery() {
+        super();
         rootEntityRef = null;
     }
 

--- a/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSRepositoryConnectorProvider.java
+++ b/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSRepositoryConnectorProvider.java
@@ -25,6 +25,13 @@ import java.util.List;
  *     <li><code>syncIndex</code>: a boolean indicating whether writes should be done synchronously (true, default) to
  *         ensure the index is up-to-date before returning, or asynchronously (false) to ensure that the transaction is
  *         recorded but that the index can be eventually consistent (faster writes)</li>
+ *     <li><code>luceneRegexes</code>: a boolean indicating whether any unquoted regexes (those not surrounded by
+ *         <code>\Q</code> and <code>\E</code>) should be treated as Lucene regexes (true) or not (false). Technically
+ *         the search interfaces are meant to take Java regexes; however, if usage of the connector is only expected to
+ *         pass fairly simple regexes that are also supported by Lucene, enabling this should significantly improve the
+ *         performance of queries against text data that involves regexes that are unquoted. (Regexes that are quoted
+ *         will be handled appropriately irrespective of this setting.)  Note that this will have no impact if Lucene
+ *         itself is not configured.</li>
  * </ul><br>
  * For example:
  * <code>
@@ -59,7 +66,8 @@ import java.util.List;
  *         "poll-wait-duration": "PT1S"
  *       }
  *     },
- *     "syncIndex": false
+ *     "syncIndex": false,
+ *     "luceneRegexes": true
  *   }
  * }
  * </code>
@@ -72,6 +80,7 @@ public class CruxOMRSRepositoryConnectorProvider extends OMRSRepositoryConnector
 
     public static final String CRUX_CONFIG = "cruxConfig";
     public static final String SYNCHRONOUS_INDEX = "syncIndex";
+    public static final String LUCENE_REGEXES = "luceneRegexes";
 
     /**
      * Constructor used to initialize the ConnectorProviderBase with the Java class name of the specific
@@ -93,6 +102,7 @@ public class CruxOMRSRepositoryConnectorProvider extends OMRSRepositoryConnector
         List<String> configProperties = new ArrayList<>();
         configProperties.add(CRUX_CONFIG);
         configProperties.add(SYNCHRONOUS_INDEX);
+        configProperties.add(LUCENE_REGEXES);
         connectorType.setRecognizedConfigurationProperties(configProperties);
 
         super.connectorTypeBean = connectorType;


### PR DESCRIPTION
Implements Lucene queries, based on a CustomAnalyzer using KeywordAnalyzer and lowercase filtering (to support an initial case-insensitive search whose results can later be narrowed to case-sensitive, if needed).  (Note that this therefore relies on a custom implementation of the `crux-lucene` module currently, which has not yet been integrated into the build here...)

Also addresses #40 by ensuring any text or property-based criteria is used first (before any type narrowing), as in almost all cases the initial text-based query against Lucene will likely be faster and for property-based searches the type limiters are already baked-in to the property query that is constructed.