### PR TITLE
Fixes and cleanups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <maven-compiler.version>3.8.1</maven-compiler.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <spotbugs.version>4.2.0</spotbugs.version>
+        <spotbugs.version>4.2.2</spotbugs.version>
         <surefire.plugin.version>3.0.0-M5</surefire.plugin.version>
     </properties>
 
@@ -254,7 +254,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>6.1.2</version>
+                    <version>6.1.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/odpi/egeria/connectors/juxt/crux/mapping/InstanceHeaderMapping.java
+++ b/src/main/java/org/odpi/egeria/connectors/juxt/crux/mapping/InstanceHeaderMapping.java
@@ -4,7 +4,6 @@ package org.odpi.egeria.connectors.juxt.crux.mapping;
 
 import crux.api.CruxDocument;
 import org.odpi.egeria.connectors.juxt.crux.repositoryconnector.CruxOMRSRepositoryConnector;
-import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.instances.EntityDetail;
 import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.instances.InstanceHeader;
 import org.odpi.openmetadata.repositoryservices.connectors.stores.metadatacollectionstore.properties.typedefs.TypeDefCategory;
 import org.slf4j.Logger;
@@ -22,12 +21,14 @@ public class InstanceHeaderMapping extends InstanceAuditHeaderMapping {
 
     private static final Logger log = LoggerFactory.getLogger(InstanceHeaderMapping.class);
 
-    private static final String INSTANCE_URL = ("instanceURL");
+    private static final String INSTANCE_URL = "instanceURL";
+    private static final String RE_IDENTIFIED_FROM_GUID = "reIdentifiedFromGUID";
 
     private static final Set<String> KNOWN_PROPERTIES = createKnownProperties();
     private static Set<String> createKnownProperties() {
         Set<String> set = new HashSet<>();
         set.add(INSTANCE_URL);
+        set.add(RE_IDENTIFIED_FROM_GUID);
         return set;
     }
 
@@ -76,6 +77,7 @@ public class InstanceHeaderMapping extends InstanceAuditHeaderMapping {
         CruxDocument.Builder builder = CruxDocument.builder(getGuidReference(instanceHeader));
         super.buildDoc(builder, instanceHeader);
         builder.put(INSTANCE_URL, instanceHeader.getInstanceURL());
+        // TODO builder.put(RE_IDENTIFIED_FROM_GUID, instanceHeader.getReIdentifiedFromGUID());
         return builder;
     }
 
@@ -91,6 +93,8 @@ public class InstanceHeaderMapping extends InstanceAuditHeaderMapping {
             String value = objValue == null ? null : objValue.toString();
             if (INSTANCE_URL.equals(property)) {
                 instanceHeader.setInstanceURL(value);
+            } else if (RE_IDENTIFIED_FROM_GUID.equals(property)) {
+                // TODO instanceHeader.setReIdentifiedFromGUID(value);
             } else {
                 log.warn("Unmapped InstanceHeader property ({}): {}", property, objValue);
             }

--- a/src/main/java/org/odpi/egeria/connectors/juxt/crux/model/search/ConditionBuilder.java
+++ b/src/main/java/org/odpi/egeria/connectors/juxt/crux/model/search/ConditionBuilder.java
@@ -34,6 +34,8 @@ public class ConditionBuilder {
     public static final Symbol AND_OPERATOR = Symbol.intern("and");
     public static final Symbol NOT_OPERATOR = Symbol.intern("not");
     public static final Symbol OR_JOIN = Symbol.intern("or-join");
+    protected static final Symbol EQ_OPERATOR = Symbol.intern("=");
+    protected static final Symbol NEQ_OPERATOR = Symbol.intern("not=");
     protected static final Symbol GT_OPERATOR = Symbol.intern(">");
     protected static final Symbol GTE_OPERATOR = Symbol.intern(">=");
     protected static final Symbol LT_OPERATOR = Symbol.intern("<");
@@ -47,6 +49,8 @@ public class ConditionBuilder {
     protected static final Map<PropertyComparisonOperator, Symbol> PCO_TO_SYMBOL = createPropertyComparisonOperatorToSymbolMap();
     private static Map<PropertyComparisonOperator, Symbol> createPropertyComparisonOperatorToSymbolMap() {
         Map<PropertyComparisonOperator, Symbol> map = new HashMap<>();
+        map.put(PropertyComparisonOperator.EQ, EQ_OPERATOR);
+        map.put(PropertyComparisonOperator.NEQ, NEQ_OPERATOR);
         map.put(PropertyComparisonOperator.GT, GT_OPERATOR);
         map.put(PropertyComparisonOperator.GTE, GTE_OPERATOR);
         map.put(PropertyComparisonOperator.LT, LT_OPERATOR);
@@ -198,10 +202,6 @@ public class ConditionBuilder {
         if (comparator.equals(PropertyComparisonOperator.EQ)) {
             // For equality we can compare directly to the value and short-circuit any additional processing
             propertyConditions.add(getEqualsConditions(propertyRef, value));
-            return propertyConditions;
-        } else if (comparator.equals(PropertyComparisonOperator.NEQ)) {
-            // Similarly for inequality, just by wrapping in a NOT predicate and short-circuit any additional processing
-            propertyConditions.add(getNotEqualsConditions(propertyRef, value));
             return propertyConditions;
         } else {
             Symbol predicate = getPredicateForOperator(comparator);
@@ -503,19 +503,6 @@ public class ConditionBuilder {
      */
     private static IPersistentCollection getEqualsConditions(Keyword propertyRef, InstancePropertyValue value) {
         return PersistentVector.create(CruxQuery.DOC_ID, propertyRef, InstancePropertyValueMapping.getValueForComparison(value));
-    }
-
-    /**
-     * Retrieve conditions to match where the provided property's value does not equal the provided value.
-     * @param propertyRef whose value should be compared
-     * @param value to compare against
-     * @return IPersistentCollection giving the conditions
-     */
-    private static IPersistentCollection getNotEqualsConditions(Keyword propertyRef, InstancePropertyValue value) {
-        List<Object> predicateComparison = new ArrayList<>();
-        predicateComparison.add(NOT_OPERATOR);
-        predicateComparison.add(PersistentVector.create(CruxQuery.DOC_ID, propertyRef, InstancePropertyValueMapping.getValueForComparison(value)));
-        return PersistentList.create(predicateComparison);
     }
 
     /**

--- a/src/main/java/org/odpi/egeria/connectors/juxt/crux/model/search/CruxQuery.java
+++ b/src/main/java/org/odpi/egeria/connectors/juxt/crux/model/search/CruxQuery.java
@@ -115,6 +115,11 @@ public class CruxQuery {
     public void addTypeDefCategoryCondition(TypeDefCategory category) {
         if (category != null) {
             conditions.add(PersistentVector.create(DOC_ID, Keyword.intern(InstanceAuditHeaderMapping.TYPE_DEF_CATEGORY), category.getOrdinal()));
+            if (category.equals(TypeDefCategory.ENTITY_DEF)) {
+                // If we are searching for an entity, additionally enforce that we retrieve only full entities
+                // (not proxies)
+                conditions.add(PersistentVector.create(DOC_ID, Keyword.intern(EntityProxyMapping.ENTITY_PROXY_ONLY_MARKER), false));
+            }
         }
     }
 

--- a/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSMetadataCollection.java
+++ b/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSMetadataCollection.java
@@ -1184,7 +1184,7 @@ public class CruxOMRSMetadataCollection extends OMRSDynamicTypeMetadataCollectio
             repositoryValidator.validateClassificationProperties(repositoryName, classificationName, propertiesParameterName, classificationProperties, methodName);
             if (externalSourceGUID == null) {
                 newClassification = repositoryHelper.getNewClassification(repositoryName,
-                        null,
+                        metadataCollectionId,
                         InstanceProvenanceType.LOCAL_COHORT,
                         userId,
                         classificationName,
@@ -2001,7 +2001,7 @@ public class CruxOMRSMetadataCollection extends OMRSDynamicTypeMetadataCollectio
                     updatedEntity = repositoryHelper.incrementVersion(userId, retrievedEntity, updatedEntity);
                     cruxRepositoryConnector.updateEntity(updatedEntity);
                 } else {
-                    cruxRepositoryConnector.saveReferenceCopy(entity);
+                    cruxRepositoryConnector.saveReferenceCopy(updatedEntity);
                 }
             } catch (EntityNotKnownException e) {
                 // Ignore since the entity has been removed since the classification was added

--- a/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSMetadataCollection.java
+++ b/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSMetadataCollection.java
@@ -314,13 +314,13 @@ public class CruxOMRSMetadataCollection extends OMRSDynamicTypeMetadataCollectio
         classificationConditions.add(condition);
         searchClassifications.setConditions(classificationConditions);
 
-        // Since matchCriteria passed are embedded with properties, the overall matchCriteria should be to all (?)
+        // Since matchCriteria passed are embedded with properties, the overall matchCriteria should be all (?)
         searchClassifications.setMatchCriteria(MatchCriteria.ALL);
 
         return findEntities(userId,
                 entityTypeGUID,
                 null,
-                searchProperties,
+                null,
                 fromEntityElement,
                 limitResultsByStatus,
                 searchClassifications,

--- a/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSRepositoryConnector.java
+++ b/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSRepositoryConnector.java
@@ -1457,7 +1457,7 @@ public class CruxOMRSRepositoryConnector extends OMRSRepositoryConnector {
 
         final String methodName = "getPreviousVersionsOfRelationship";
         List<Relationship> results = new ArrayList<>();
-        String docRef = EntitySummaryMapping.getReference(guid);
+        String docRef = RelationshipMapping.getReference(guid);
 
         // Open the database view at the latest point against which we are interested
         try (ICruxDatasource db = to == null ? cruxAPI.openDB() : cruxAPI.openDB(to)) {
@@ -2156,7 +2156,9 @@ public class CruxOMRSRepositoryConnector extends OMRSRepositoryConnector {
      * @return TransactionInstant transaction details
      */
     public TransactionInstant runTx(Transaction statements) {
-        log.debug("{} transacting with: {}", synchronousIndex ? SYNC : ASYNC, statements);
+        if (log.isDebugEnabled()) {
+            log.debug("{} transacting with: {}", synchronousIndex ? SYNC : ASYNC, statements.toVector());
+        }
         TransactionInstant tx = cruxAPI.submitTx(statements);
         // Null for the timeout here means use the default (which is therefore configurable directly by the Crux
         // configurationProperties of the connector)

--- a/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSRepositoryConnector.java
+++ b/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSRepositoryConnector.java
@@ -2106,15 +2106,16 @@ public class CruxOMRSRepositoryConnector extends OMRSRepositoryConnector {
         if (results == null || results.isEmpty()) {
             return results;
         } else {
-            List<List<?>> pageOfResults = new ArrayList<>();
+            List<List<?>> pageOfResults  = new ArrayList<>();
+            Set<List<?>> skippedResults = new HashSet<>();
             int currentIndex = 0;
             // 0 as a pageSize means ALL pages -- so we should return every result that we found (up to the maximum
             // number of results allowed by the connector)
             pageSize = pageSize > 0 ? pageSize : getMaxPageSize();
             int lastResultIndex = (fromElement + pageSize);
             for (List<?> singleResult : results) {
-                // If we are at / beyond the last index, break out of the loop
                 if (currentIndex >= lastResultIndex) {
+                    // If we are at / beyond the last index, break out of the loop
                     break;
                 } else if (currentIndex >= fromElement && !pageOfResults.contains(singleResult)) {
                     // Otherwise, only add this result if it is at or beyond the starting point (fromElement) and
@@ -2122,7 +2123,15 @@ public class CruxOMRSRepositoryConnector extends OMRSRepositoryConnector {
                     // current index for the number of results we have captured)
                     pageOfResults.add(singleResult);
                     currentIndex++;
+                } else if (!skippedResults.contains(singleResult)) {
+                    // Otherwise, remember that we have skipped this result and increment the current index
+                    // accordingly
+                    skippedResults.add(singleResult);
+                    currentIndex++;
                 }
+                // In any other scenario, it is a result that has already been included or already been skipped,
+                // so we do not need to increment our index or do anything with the result -- just move on to the
+                // next one
             }
             return pageOfResults;
         }


### PR DESCRIPTION
- Fixes paging of search results
- Fixes classification reference copy handling
- Optimization to avoid retrieving entity proxies via searches (since no search method allows them to be returned anyway)
- Fixes relationship history retrieval
- Implements more robust (history-aware) logic for reIdentify methods