### PR TITLE
Implements logic from odpi/egeria#5183 for cascading deletes

### DIFF
--- a/connector/src/main/java/org/odpi/egeria/connectors/juxt/crux/model/search/CruxGraphQuery.java
+++ b/connector/src/main/java/org/odpi/egeria/connectors/juxt/crux/model/search/CruxGraphQuery.java
@@ -42,17 +42,16 @@ public class CruxGraphQuery extends CruxQuery {
             // [r :type.guids ...]
             conditions.addAll(getTypeCondition(RELATIONSHIP, TypeDefCategory.RELATIONSHIP_DEF, null, relationshipTypeGUIDs));
         }
-        if (limitResultsByStatus != null && !limitResultsByStatus.isEmpty()) {
-            conditions.addAll(getStatusLimiters(RELATIONSHIP, limitResultsByStatus));
-        }
+        addStatusLimiters(limitResultsByStatus, RELATIONSHIP);
     }
 
     /**
      * Add condition(s) to limit the resulting entities by the provided criteria.
      * @param entityTypeGUIDs entity type definitions by which to limit
      * @param limitResultsByClassification entity classifications by which to limit
+     * @param limitResultsByStatus of entity statuses by which to limit the results
      */
-    public void addEntityLimiters(List<String> entityTypeGUIDs, List<String> limitResultsByClassification) {
+    public void addEntityLimiters(List<String> entityTypeGUIDs, List<String> limitResultsByClassification, List<InstanceStatus> limitResultsByStatus) {
         if (entityTypeGUIDs != null && !entityTypeGUIDs.isEmpty()) {
             // [e :type.guids ...]
             conditions.addAll(getTypeCondition(DOC_ID, TypeDefCategory.ENTITY_DEF, null, entityTypeGUIDs));
@@ -62,6 +61,7 @@ public class CruxGraphQuery extends CruxQuery {
             // [e :classifications classification] [(hash-set "..." "..." ...) cf] [(contains? cf classification)]
             conditions.addAll(getClassificationConditions(limitResultsByClassification));
         }
+        addStatusLimiters(limitResultsByStatus, DOC_ID);
     }
 
     /**

--- a/connector/src/main/java/org/odpi/egeria/connectors/juxt/crux/model/search/CruxQuery.java
+++ b/connector/src/main/java/org/odpi/egeria/connectors/juxt/crux/model/search/CruxQuery.java
@@ -248,19 +248,20 @@ public class CruxQuery {
     /**
      * Add the provided statuses as limiters on which results should be retrieved from the query.
      * @param limitResultsByStatus list of statuses by which to limit results
+     * @param toLimit variable by which to limit by status (e.g. entity or relationship)
      */
-    public void addStatusLimiters(List<InstanceStatus> limitResultsByStatus) {
+    public void addStatusLimiters(List<InstanceStatus> limitResultsByStatus, Symbol toLimit) {
         if (limitResultsByStatus != null && !limitResultsByStatus.isEmpty()) {
-            List<IPersistentCollection> statusConditions = getStatusLimiters(DOC_ID, limitResultsByStatus);
+            List<IPersistentCollection> statusConditions = getStatusLimiters(toLimit, limitResultsByStatus);
             if (statusConditions != null && !statusConditions.isEmpty()) {
                 conditions.addAll(statusConditions);
             }
         } else {
             // If no status limit was specified, retrieve only non-DELETED objects
             Integer deleted = EnumPropertyValueMapping.getOrdinalForInstanceStatus(InstanceStatus.DELETED);
-            Symbol variable = Symbol.intern(InstanceAuditHeaderMapping.CURRENT_STATUS);
+            Symbol variable = Symbol.intern(toLimit.toString() + "_" + InstanceAuditHeaderMapping.CURRENT_STATUS);
             Keyword propertyRef = Keyword.intern(InstanceAuditHeaderMapping.CURRENT_STATUS);
-            conditions.add(PersistentVector.create(DOC_ID, propertyRef, variable));
+            conditions.add(PersistentVector.create(toLimit, propertyRef, variable));
             List<Object> predicateComparison = new ArrayList<>();
             predicateComparison.add(ConditionBuilder.NEQ_OPERATOR);
             predicateComparison.add(variable);

--- a/connector/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSMetadataCollection.java
+++ b/connector/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSMetadataCollection.java
@@ -950,7 +950,7 @@ public class CruxOMRSMetadataCollection extends OMRSDynamicTypeMetadataCollectio
         // 1. Remove every relationship in which the entity is involved, to maintain referential integrity within the
         //    repository
         try {
-            List<Relationship> relationships = cruxRepositoryConnector.findRelationshipsForEntity(entity, userId);
+            List<Relationship> relationships = cruxRepositoryConnector.findActiveRelationshipsForEntity(entity, userId);
             if (relationships != null) {
                 for (Relationship relationship : relationships) {
                     if (relationship != null) {
@@ -1027,7 +1027,8 @@ public class CruxOMRSMetadataCollection extends OMRSDynamicTypeMetadataCollectio
         try {
             Collection<List<?>> relationshipRefs = cruxRepositoryConnector.findEntityRelationships(cruxRepositoryConnector.getCruxAPI().db(),
                     deletedEntityGUID,
-                    userId);
+                    userId,
+                    true);
             for (List<?> relationshipRef : relationshipRefs) {
                 String docRef = (String) relationshipRef.get(0);
                 String guid = RelationshipMapping.trimGuidFromReference(docRef);

--- a/connector/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSRepositoryConnector.java
+++ b/connector/src/main/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSRepositoryConnector.java
@@ -565,15 +565,15 @@ public class CruxOMRSRepositoryConnector extends OMRSRepositoryConnector {
     }
 
     /**
-     * Find all relationships in this repository for the provided entity.
+     * Find all active (non-deleted) relationships in this repository for the provided entity.
      * @param entity for which to find relationships
      * @param userId of the user running the query
      * @return {@code List<Relationship>} list of the homed relationships
      * @throws RepositoryErrorException if any issue closing open Crux resources
      * @throws RepositoryTimeoutException if the query runs longer than the defined threshold (default: 30s)
      */
-    public List<Relationship> findRelationshipsForEntity(EntityDetail entity,
-                                                         String userId) throws RepositoryErrorException, RepositoryTimeoutException {
+    public List<Relationship> findActiveRelationshipsForEntity(EntityDetail entity,
+                                                               String userId) throws RepositoryErrorException, RepositoryTimeoutException {
 
         final String methodName = "findRelationshipsForEntity";
         List<Relationship> results;
@@ -584,7 +584,8 @@ public class CruxOMRSRepositoryConnector extends OMRSRepositoryConnector {
 
             Collection<List<?>> cruxResults = findEntityRelationships(db,
                     entity.getGUID(),
-                    userId);
+                    userId,
+                    false);
 
             log.debug("Found results: {}", cruxResults);
             results = resultsToList(db, cruxResults);
@@ -2075,26 +2076,32 @@ public class CruxOMRSRepositoryConnector extends OMRSRepositoryConnector {
      * @param db already opened point-in-time view of the database
      * @param entityGUID for which to find relationships
      * @param userId of the user running the query
+     * @param includeDeleted if true, include deleted relationships in the results (otherwise exclude them)
      * @return {@code Collection<List<?>>} list of the Crux document references that match
      * @throws TimeoutException if the query runs longer than the defined threshold (default: 30s)
      */
     public Collection<List<?>> findEntityRelationships(ICruxDatasource db,
                                                        String entityGUID,
-                                                       String userId) throws TimeoutException {
+                                                       String userId,
+                                                       boolean includeDeleted) throws TimeoutException {
         CruxQuery query = new CruxQuery();
         query.addRelationshipEndpointConditions(EntitySummaryMapping.getReference(entityGUID));
         try {
-            updateQuery(query,
-                    TypeDefCategory.RELATIONSHIP_DEF,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    userId);
+            if (includeDeleted) {
+                query.addTypeCondition(TypeDefCategory.RELATIONSHIP_DEF, null, null);
+            } else {
+                updateQuery(query,
+                        TypeDefCategory.RELATIONSHIP_DEF,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        userId);
+            }
         } catch (TypeErrorException e) {
             log.error("Unexpected type error, when no types are being explicitly used.", e);
         }
@@ -2171,7 +2178,7 @@ public class CruxOMRSRepositoryConnector extends OMRSRepositoryConnector {
                                                    List<String> limitResultsByClassification) throws TimeoutException {
         CruxGraphQuery query = new CruxGraphQuery();
         query.addRelationshipLimiters(entityGUID, relationshipTypeGUIDs, limitResultsByStatus);
-        query.addEntityLimiters(entityTypeGUIDs, limitResultsByClassification);
+        query.addEntityLimiters(entityTypeGUIDs, limitResultsByClassification, limitResultsByStatus);
         IPersistentMap q = query.getQuery();
         log.debug("Querying with: {}", q);
         return db.query(q);
@@ -2210,7 +2217,10 @@ public class CruxOMRSRepositoryConnector extends OMRSRepositoryConnector {
         query.addTypeCondition(category, typeGuid, subtypeGuids);
         query.addClassificationConditions(matchClassifications, completeTypeSet, repositoryHelper, repositoryName, luceneConfigured, luceneRegexes);
         query.addSequencing(sequencingOrder, sequencingProperty, namespace, completeTypeSet, repositoryHelper, repositoryName);
-        query.addStatusLimiters(limitResultsByStatus);
+        // Note: we will always limit by 'e', even if the TypeDefCategory indicates this is a relationship as these
+        // operations only ever return a single type of instance (entity or relationship), and 'e' is therefore used
+        // generally to represent either
+        query.addStatusLimiters(limitResultsByStatus, CruxQuery.DOC_ID);
     }
 
     /**
@@ -2248,7 +2258,10 @@ public class CruxOMRSRepositoryConnector extends OMRSRepositoryConnector {
         query.addTypeCondition(category, typeGuid, null);
         query.addClassificationConditions(matchClassifications, completeTypeSet, repositoryHelper, repositoryName, luceneConfigured, luceneRegexes);
         query.addSequencing(sequencingOrder, sequencingProperty, namespace, completeTypeSet, repositoryHelper, repositoryName);
-        query.addStatusLimiters(limitResultsByStatus);
+        // Note: we will always limit by 'e', even if the TypeDefCategory indicates this is a relationship as these
+        // operations only ever return a single type of instance (entity or relationship), and 'e' is therefore used
+        // generally to represent either
+        query.addStatusLimiters(limitResultsByStatus, CruxQuery.DOC_ID);
     }
 
     /**

--- a/connector/src/test/java/org/odpi/egeria/connectors/juxt/crux/model/search/CruxGraphQueryTest.java
+++ b/connector/src/test/java/org/odpi/egeria/connectors/juxt/crux/model/search/CruxGraphQueryTest.java
@@ -37,8 +37,8 @@ public class CruxGraphQueryTest {
             Object candidate = relation.valAt(where);
             assertTrue(candidate instanceof IPersistentVector, "Where conditions are expected to be enclosed in an outer vector.");
             IPersistentVector conditions = (IPersistentVector) candidate;
-            assertEquals(conditions.length(), 2, "Two conditions are expected for limiting by relationships without status or type.");
-            // Expected --> [[r :entityProxies e] [r :entityProxies "e_123"]]
+            assertEquals(conditions.length(), 4, "Four conditions are expected for limiting by relationships without status or type.");
+            // Expected --> [[r :entityProxies e] [r :entityProxies "e_123"] [r :currentStatus r_currentStatus] [(not= r_currentStatus 99)]]
 
             candidate = conditions.nth(0);
             assertTrue(candidate instanceof IPersistentVector, "Where conditions are are expected to be enclosed in an inner vector.");
@@ -55,6 +55,30 @@ public class CruxGraphQueryTest {
             assertEquals(condition.nth(0), CruxGraphQuery.RELATIONSHIP, "First element of triple is expected to be the relationship ID symbol.");
             assertEquals(condition.nth(1), Keyword.intern(RelationshipMapping.ENTITY_PROXIES), "Second element of triple is expected to be the keyword :entityProxies.");
             assertEquals(condition.nth(2), ref, "Third element of the triple is expected to be the entity reference to match.");
+
+            Symbol status = Symbol.intern("r_currentStatus");
+
+            candidate = conditions.nth(2);
+            assertTrue(candidate instanceof IPersistentVector, "Where conditions are are expected to be enclosed in an inner vector.");
+            condition = (IPersistentVector) candidate;
+            assertEquals(condition.length(), 3, "Where condition is expected to be a triple.");
+            assertEquals(condition.nth(0), CruxGraphQuery.RELATIONSHIP, "First element of triple is expected to be the relationship ID symbol.");
+            assertEquals(condition.nth(1), Keyword.intern(InstanceHeaderMapping.CURRENT_STATUS), "Second element of triple is expected to be the keyword for the status property.");
+            assertEquals(condition.nth(2), status, "Third element of the triple is expected to be the symbol to capture the status.");
+
+            candidate = conditions.nth(3);
+            assertTrue(candidate instanceof IPersistentVector, "Where conditions are are expected to be enclosed in an inner vector.");
+            condition = (IPersistentVector) candidate;
+            assertEquals(condition.length(), 1, "Where condition is expected to be a single list.");
+            candidate = condition.nth(0);
+            assertTrue(candidate instanceof IPersistentList, "Clause is expected to begin with a list.");
+            IPersistentList clause = (IPersistentList) candidate;
+            assertEquals(clause.count(), 3, "Clause list is expected to contain at least 2 elements.");
+            List<Object> compare = new ArrayList<>();
+            compare.add(ConditionBuilder.NEQ_OPERATOR);
+            compare.add(status);
+            compare.add(99);
+            assertEquals(clause, PersistentList.create(compare), "Clause is expected to check that the set of status is not deleted (99).");
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -82,8 +106,8 @@ public class CruxGraphQueryTest {
             Object candidate = relation.valAt(where);
             assertTrue(candidate instanceof IPersistentVector, "Where conditions are expected to be enclosed in an outer vector.");
             IPersistentVector conditions = (IPersistentVector) candidate;
-            assertEquals(conditions.length(), 3, "Three conditions are expected for limiting by relationships by type.");
-            // Expected --> [[r :entityProxies e] [r :entityProxies "e_123"] [r :type.guids "e6670973-645f-441a-bec7-6f5570345b92"]]
+            assertEquals(conditions.length(), 5, "Five conditions are expected for limiting by relationships by type.");
+            // Expected --> [[r :entityProxies e] [r :entityProxies "e_123"] [r :type.guids "e6670973-645f-441a-bec7-6f5570345b92"] [r :currentStatus r_currentStatus] [(not= r_currentStatus 99)]]
 
             candidate = conditions.nth(0);
             assertTrue(candidate instanceof IPersistentVector, "Where conditions are are expected to be enclosed in an inner vector.");
@@ -108,6 +132,30 @@ public class CruxGraphQueryTest {
             assertEquals(condition.nth(0), CruxGraphQuery.RELATIONSHIP, "First element of triple is expected to be the relationship ID symbol.");
             assertEquals(condition.nth(1), Keyword.intern(InstanceHeaderMapping.TYPE_DEF_GUIDS), "Second element of triple is expected to be the keyword for the typeDef GUIDs.");
             assertEquals(condition.nth(2), types.get(0), "Third element of the triple is expected to be the relationship typeDef GUID to match.");
+
+            Symbol status = Symbol.intern("r_currentStatus");
+
+            candidate = conditions.nth(3);
+            assertTrue(candidate instanceof IPersistentVector, "Where conditions are are expected to be enclosed in an inner vector.");
+            condition = (IPersistentVector) candidate;
+            assertEquals(condition.length(), 3, "Where condition is expected to be a triple.");
+            assertEquals(condition.nth(0), CruxGraphQuery.RELATIONSHIP, "First element of triple is expected to be the relationship ID symbol.");
+            assertEquals(condition.nth(1), Keyword.intern(InstanceHeaderMapping.CURRENT_STATUS), "Second element of triple is expected to be the keyword for the status property.");
+            assertEquals(condition.nth(2), status, "Third element of the triple is expected to be the symbol to capture the status.");
+
+            candidate = conditions.nth(4);
+            assertTrue(candidate instanceof IPersistentVector, "Where conditions are are expected to be enclosed in an inner vector.");
+            condition = (IPersistentVector) candidate;
+            assertEquals(condition.length(), 1, "Where condition is expected to be a single list.");
+            candidate = condition.nth(0);
+            assertTrue(candidate instanceof IPersistentList, "Clause is expected to begin with a list.");
+            IPersistentList clause = (IPersistentList) candidate;
+            assertEquals(clause.count(), 3, "Clause list is expected to contain at least 2 elements.");
+            List<Object> compare = new ArrayList<>();
+            compare.add(ConditionBuilder.NEQ_OPERATOR);
+            compare.add(status);
+            compare.add(99);
+            assertEquals(clause, PersistentList.create(compare), "Clause is expected to check that the set of status is not deleted (99).");
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -211,7 +259,7 @@ public class CruxGraphQueryTest {
             types.add("a32316b8-dc8c-48c5-b12b-71c1b2a080bf");
 
             CruxGraphQuery cgq = new CruxGraphQuery();
-            cgq.addEntityLimiters(types, null);
+            cgq.addEntityLimiters(types, null, null);
             IPersistentMap entities = cgq.getQuery();
             assertNotNull(entities);
             assertTrue(entities.containsKey(find));
@@ -220,8 +268,8 @@ public class CruxGraphQueryTest {
             Object candidate = entities.valAt(where);
             assertTrue(candidate instanceof IPersistentVector, "Where conditions are expected to be enclosed in an outer vector.");
             IPersistentVector conditions = (IPersistentVector) candidate;
-            assertEquals(conditions.length(), 1, "One condition is expected for limiting entities by a single type.");
-            // Expected --> [[e :type.guids "a32316b8-dc8c-48c5-b12b-71c1b2a080bf"]]
+            assertEquals(conditions.length(), 3, "Three conditions are expected for limiting entities by a single type.");
+            // Expected --> [[e :type.guids "a32316b8-dc8c-48c5-b12b-71c1b2a080bf"] [e :currentStatus e_currentStatus] [(not= e_currentStatus 99)]]
 
             candidate = conditions.nth(0);
             assertTrue(candidate instanceof IPersistentVector, "Where conditions are are expected to be enclosed in an inner vector.");
@@ -230,6 +278,30 @@ public class CruxGraphQueryTest {
             assertEquals(condition.nth(0), CruxQuery.DOC_ID, "First element of triple is expected to be the relationship ID symbol.");
             assertEquals(condition.nth(1), Keyword.intern(InstanceHeaderMapping.TYPE_DEF_GUIDS), "Second element of triple is expected to be the keyword for typeDef GUIDs.");
             assertEquals(condition.nth(2), types.get(0), "Third element of the triple is expected to be the value of the typeDef GUID by which to limit.");
+
+            Symbol status = Symbol.intern("e_currentStatus");
+
+            candidate = conditions.nth(1);
+            assertTrue(candidate instanceof IPersistentVector, "Where conditions are are expected to be enclosed in an inner vector.");
+            condition = (IPersistentVector) candidate;
+            assertEquals(condition.length(), 3, "Where condition is expected to be a triple.");
+            assertEquals(condition.nth(0), CruxGraphQuery.DOC_ID, "First element of triple is expected to be the entity ID symbol.");
+            assertEquals(condition.nth(1), Keyword.intern(InstanceHeaderMapping.CURRENT_STATUS), "Second element of triple is expected to be the keyword for the status property.");
+            assertEquals(condition.nth(2), status, "Third element of the triple is expected to be the symbol to capture the status.");
+
+            candidate = conditions.nth(2);
+            assertTrue(candidate instanceof IPersistentVector, "Where conditions are are expected to be enclosed in an inner vector.");
+            condition = (IPersistentVector) candidate;
+            assertEquals(condition.length(), 1, "Where condition is expected to be a single list.");
+            candidate = condition.nth(0);
+            assertTrue(candidate instanceof IPersistentList, "Clause is expected to begin with a list.");
+            IPersistentList clause = (IPersistentList) candidate;
+            assertEquals(clause.count(), 3, "Clause list is expected to contain at least 2 elements.");
+            List<Object> compare = new ArrayList<>();
+            compare.add(ConditionBuilder.NEQ_OPERATOR);
+            compare.add(status);
+            compare.add(99);
+            assertEquals(clause, PersistentList.create(compare), "Clause is expected to check that the set of status is not deleted (99).");
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -248,7 +320,7 @@ public class CruxGraphQueryTest {
             Symbol cf = Symbol.intern("cf");
 
             CruxGraphQuery cgq = new CruxGraphQuery();
-            cgq.addEntityLimiters(null, classificationNames);
+            cgq.addEntityLimiters(null, classificationNames, null);
             IPersistentMap entities = cgq.getQuery();
             assertNotNull(entities);
             assertTrue(entities.containsKey(find));
@@ -257,8 +329,8 @@ public class CruxGraphQueryTest {
             Object candidate = entities.valAt(where);
             assertTrue(candidate instanceof IPersistentVector, "Where conditions are expected to be enclosed in an outer vector.");
             IPersistentVector conditions = (IPersistentVector) candidate;
-            assertEquals(conditions.length(), 3, "Three condition are expected for limiting entities by multiple classifications.");
-            // Expected --> [[e :classifications classification] [(hash-set "Confidentiality" "MobileAsset") cf] [(contains? cf classification)]]
+            assertEquals(conditions.length(), 5, "Five conditions are expected for limiting entities by multiple classifications.");
+            // Expected --> [[e :classifications classification] [(hash-set "Confidentiality" "MobileAsset") cf] [(contains? cf classification)] [e :currentStatus e_currentStatus] [(not= e_currentStatus 99)]]
 
             candidate = conditions.nth(0);
             assertTrue(candidate instanceof IPersistentVector, "Where conditions are are expected to be enclosed in an inner vector.");
@@ -297,6 +369,30 @@ public class CruxGraphQueryTest {
             compare.add(cf);
             compare.add(classification);
             assertEquals(clause, PersistentList.create(compare), "Clause is expected to check that the set of classifications contains the value being searched.");
+
+            Symbol status = Symbol.intern("e_currentStatus");
+
+            candidate = conditions.nth(3);
+            assertTrue(candidate instanceof IPersistentVector, "Where conditions are are expected to be enclosed in an inner vector.");
+            condition = (IPersistentVector) candidate;
+            assertEquals(condition.length(), 3, "Where condition is expected to be a triple.");
+            assertEquals(condition.nth(0), CruxGraphQuery.DOC_ID, "First element of triple is expected to be the entity ID symbol.");
+            assertEquals(condition.nth(1), Keyword.intern(InstanceHeaderMapping.CURRENT_STATUS), "Second element of triple is expected to be the keyword for the status property.");
+            assertEquals(condition.nth(2), status, "Third element of the triple is expected to be the symbol to capture the status.");
+
+            candidate = conditions.nth(4);
+            assertTrue(candidate instanceof IPersistentVector, "Where conditions are are expected to be enclosed in an inner vector.");
+            condition = (IPersistentVector) candidate;
+            assertEquals(condition.length(), 1, "Where condition is expected to be a single list.");
+            candidate = condition.nth(0);
+            assertTrue(candidate instanceof IPersistentList, "Clause is expected to begin with a list.");
+            clause = (IPersistentList) candidate;
+            assertEquals(clause.count(), 3, "Clause list is expected to contain at least 2 elements.");
+            compare = new ArrayList<>();
+            compare.add(ConditionBuilder.NEQ_OPERATOR);
+            compare.add(status);
+            compare.add(99);
+            assertEquals(clause, PersistentList.create(compare), "Clause is expected to check that the set of status is not deleted (99).");
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/connector/src/test/java/org/odpi/egeria/connectors/juxt/crux/model/search/CruxQueryTest.java
+++ b/connector/src/test/java/org/odpi/egeria/connectors/juxt/crux/model/search/CruxQueryTest.java
@@ -322,10 +322,10 @@ public class CruxQueryTest {
     void testStatusLimitersDefault() {
         try {
 
-            Symbol currentStatus = Symbol.intern("currentStatus");
+            Symbol currentStatus = Symbol.intern("e_currentStatus");
 
             CruxQuery cq = new CruxQuery();
-            cq.addStatusLimiters(null);
+            cq.addStatusLimiters(null, CruxQuery.DOC_ID);
 
             IPersistentMap limitByStatus = cq.getQuery();
             assertNotNull(limitByStatus);
@@ -377,7 +377,7 @@ public class CruxQueryTest {
             limitBy.add(InstanceStatus.DELETED);
 
             CruxQuery cq = new CruxQuery();
-            cq.addStatusLimiters(limitBy);
+            cq.addStatusLimiters(limitBy, CruxQuery.DOC_ID);
 
             IPersistentMap limitByStatus = cq.getQuery();
             assertNotNull(limitByStatus);

--- a/connector/src/test/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSRepositoryConnectorTest.java
+++ b/connector/src/test/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSRepositoryConnectorTest.java
@@ -538,6 +538,10 @@ public class CruxOMRSRepositoryConnectorTest {
             assertNotNull(results, "Expected some search results.");
             assertEquals(results.size(), 2, "Expected precisely two search results.");
 
+            results = connector.findRelationshipsForEntity(category1, MockConnection.USERNAME);
+            assertNotNull(results, "Expected some search results.");
+            assertEquals(results.size(), 2, "Expected precisely two search results.");
+
             results = connector.findRelationshipsForEntity(category1.getGUID(),
                     "71e4b6fb-3412-4193-aff3-a16eccd87e8e",
                     0,

--- a/connector/src/test/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSRepositoryConnectorTest.java
+++ b/connector/src/test/java/org/odpi/egeria/connectors/juxt/crux/repositoryconnector/CruxOMRSRepositoryConnectorTest.java
@@ -522,6 +522,22 @@ public class CruxOMRSRepositoryConnectorTest {
             Relationship second = connector.createRelationship(two);
             assertNotNull(second, "Expected a CategoryHierarchyLink relationship to be created.");
 
+            Relationship three = helper.getSkeletonRelationship(MockConnection.SOURCE_NAME,
+                    MockConnection.METADATA_COLLECTION_ID,
+                    MockConnection.METADATA_COLLECTION_NAME,
+                    InstanceProvenanceType.LOCAL_COHORT,
+                    MockConnection.USERNAME,
+                    "CategoryHierarchyLink");
+
+            three.setEntityOneProxy(helper.getNewEntityProxy(MockConnection.SOURCE_NAME, category2));
+            three.setEntityTwoProxy(helper.getNewEntityProxy(MockConnection.SOURCE_NAME, category1));
+            three.setStatus(InstanceStatus.DELETED);
+
+            Relationship third = connector.createRelationship(three);
+            assertNotNull(third, "Expected a CategoryHierarchyLink relationship to be created.");
+            Relationship retrieved = connector.getRelationship(three.getGUID(), null);
+            assertNotNull(retrieved, "Expected to be able to retrieve the relationship back again.");
+
             List<Relationship> results = connector.findRelationshipsForEntity(category1.getGUID(),
                     null,
                     0,
@@ -538,9 +554,16 @@ public class CruxOMRSRepositoryConnectorTest {
             assertNotNull(results, "Expected some search results.");
             assertEquals(results.size(), 2, "Expected precisely two search results.");
 
-            results = connector.findRelationshipsForEntity(category1, MockConnection.USERNAME);
+            results = connector.findActiveRelationshipsForEntity(category1, MockConnection.USERNAME);
             assertNotNull(results, "Expected some search results.");
             assertEquals(results.size(), 2, "Expected precisely two search results.");
+
+            Collection<List<?>> otherResults = connector.findEntityRelationships(connector.getCruxAPI().db(),
+                    category1.getGUID(),
+                    MockConnection.USERNAME,
+                    true);
+            assertNotNull(otherResults, "Expected some search results.");
+            assertEquals(otherResults.size(), 3, "Expected precisely three search results.");
 
             results = connector.findRelationshipsForEntity(category1.getGUID(),
                     "71e4b6fb-3412-4193-aff3-a16eccd87e8e",


### PR DESCRIPTION
- Implements logic from odpi/egeria#5183 for cascading deletes (and purges) from entities to their relationships
- Addresses #149 to ensure that by default (no status limit requested) only non-deleted instances are retrieved